### PR TITLE
Update Pandas_Essential_Training.ipynb

### DIFF
--- a/Pandas_Essential_Training.ipynb
+++ b/Pandas_Essential_Training.ipynb
@@ -2466,7 +2466,7 @@
         "                \"NOC\": \"string\",\n",
         "                \"Gender\": \"category\",\n",
         "                \"Event\": \"string\",\n",
-        "                \"Event_gender\": \"category\",\n",
+        "                \"Event Gender\": \"category\",\n",
         "                \"Medal\": \"category\"}\n",
         "\n",
         "dtype_mapper"
@@ -2511,7 +2511,7 @@
         "                \"NOC\": \"string\",\n",
         "                \"Gender\": \"category\",\n",
         "                \"Event\": \"string\",\n",
-        "                \"Event_gender\": \"category\",\n",
+        "                \"Event Gender\": \"category\",\n",
         "                \"Medal\": ordered_medals}\n",
         "\n",
         "dtype_mapper"


### PR DESCRIPTION
Reading CSV with dtypes mapper was not working for Event Gender as the mapper had incorrect column name (Event_gender)

<!-- This repository *does not* accept pull requests (PRs). All pull requests will be closed. See CONTRIBUTING.md for further details. -->
